### PR TITLE
Add capability to interpret years as well

### DIFF
--- a/polenum.py
+++ b/polenum.py
@@ -60,6 +60,7 @@ def convert(low, high, lockout=False):
         minutes = int(strftime("%M", gmtime(tmp)))
         hours = int(strftime("%H", gmtime(tmp)))
         days = int(strftime("%j", gmtime(tmp)))-1
+        days += 365*(int(strftime("%Y", gmtime(tmp)))-1970)
     except ValueError as e:
         return "[-] Invalid TIME"
 

--- a/polenum.py
+++ b/polenum.py
@@ -60,10 +60,14 @@ def convert(low, high, lockout=False):
         minutes = int(strftime("%M", gmtime(tmp)))
         hours = int(strftime("%H", gmtime(tmp)))
         days = int(strftime("%j", gmtime(tmp)))-1
-        days += 365*(int(strftime("%Y", gmtime(tmp)))-1970)
+        years = int(strftime("%Y", gmtime(tmp)))-1970
     except ValueError as e:
         return "[-] Invalid TIME"
 
+    if years > 1:
+        time += "{0} years ".format(years)
+    elif years == 1:
+        time += "{0} year ".format(years)
     if days > 1:
         time += "{0} days ".format(days)
     elif days == 1:


### PR DESCRIPTION
Currently, `polenum` shows false password age values if they exceed a year. 

Microsoft documents valid values to be `0-999` [[1]](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/maximum-password-age).

For values above 364, the `strftime("j"...)` for the days goes back to zero and we must use the year formatter instead.

I added a line that adds the additional years to the day counter. (Note the `-1970` to acount for the timestamp starting at 1970).

With the proposed change, a max password age of 400 days will show up as `[+] Maximum password age: 400 days 3 minutes` instead of `[+] Maximum password age: 35 days 3 minutes`.